### PR TITLE
fix: 更新爱玛签到逻辑，修复新签到用户从第二天起无法签到的问题

### DIFF
--- a/daily/aima.js
+++ b/daily/aima.js
@@ -60,7 +60,7 @@ async function signIn(token, index) {
     );
 
     const data = searchRes.data;
-    if (data.content && data.content.signed === 1) {
+    if (data.content && data.content.signStatus === 1) {
       $.log(`✅ 账号【${index}】今日已签到！`);
       return;
     }


### PR DESCRIPTION
data.content中的signed表示已签到天数，signStatus表示当前签到状态，如果是新签到用户的话会从第二天开始一直返回已签到导致签到失败

第一天
<img width="439" height="443" alt="image" src="https://github.com/user-attachments/assets/afe21b70-a7fa-4116-a146-f7db65c436ec" />

第二天
<img width="453" height="449" alt="image" src="https://github.com/user-attachments/assets/98ae1833-8866-44d8-b25b-9e146811df2b" />
